### PR TITLE
Add settings.json configuration example for custom marketplaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,12 @@ https://github.com/DIO0550/d-market-statusline
 // ~/.claude/settings.json
 {
   "extraKnownMarketplaces": {
+    "d-market-rust": {
+      "source": {
+        "source": "github",
+        "repo": "DIO0550/d-market-rust"
+      }
+    },
     "d-market-typescript": {
       "source": {
         "source": "github",
@@ -236,6 +242,12 @@ https://github.com/DIO0550/d-market-statusline
       "source": {
         "source": "github",
         "repo": "DIO0550/d-market-react"
+      }
+    },
+    "d-market-orchestrator": {
+      "source": {
+        "source": "github",
+        "repo": "DIO0550/d-market-orchestrator"
       }
     },
     "d-market-spec": {
@@ -250,10 +262,28 @@ https://github.com/DIO0550/d-market-statusline
         "repo": "DIO0550/d-market-git"
       }
     },
+    "d-market-code-review": {
+      "source": {
+        "source": "github",
+        "repo": "DIO0550/d-market-code-review"
+      }
+    },
     "d-market-doc-gen": {
       "source": {
         "source": "github",
         "repo": "DIO0550/d-market-doc-gen"
+      }
+    },
+    "d-market-workflow": {
+      "source": {
+        "source": "github",
+        "repo": "DIO0550/d-market-workflow"
+      }
+    },
+    "d-market-file-search": {
+      "source": {
+        "source": "github",
+        "repo": "DIO0550/d-market-file-search"
       }
     },
     "d-market-statusline": {

--- a/README.md
+++ b/README.md
@@ -218,6 +218,54 @@ https://github.com/DIO0550/d-market-file-search
 https://github.com/DIO0550/d-market-statusline
 ```
 
+## settings.json での設定例
+
+`extraKnownMarketplaces` に追加することで、マーケットプレイスとして認識させることができます。
+
+```jsonc
+// ~/.claude/settings.json
+{
+  "extraKnownMarketplaces": {
+    "d-market-typescript": {
+      "source": {
+        "source": "github",
+        "repo": "DIO0550/d-market-typescript"
+      }
+    },
+    "d-market-react": {
+      "source": {
+        "source": "github",
+        "repo": "DIO0550/d-market-react"
+      }
+    },
+    "d-market-spec": {
+      "source": {
+        "source": "github",
+        "repo": "DIO0550/d-market-spec"
+      }
+    },
+    "d-market-git": {
+      "source": {
+        "source": "github",
+        "repo": "DIO0550/d-market-git"
+      }
+    },
+    "d-market-doc-gen": {
+      "source": {
+        "source": "github",
+        "repo": "DIO0550/d-market-doc-gen"
+      }
+    },
+    "d-market-statusline": {
+      "source": {
+        "source": "github",
+        "repo": "DIO0550/d-market-statusline"
+      }
+    }
+  }
+}
+```
+
 ## ライセンス
 
 [MIT](./LICENSE)


### PR DESCRIPTION
## Summary
Added documentation for configuring custom marketplaces through the `settings.json` file, providing users with a practical example of how to register additional marketplace repositories.

## Changes
- Added a new section "settings.json での設定例" (settings.json configuration example) to the README
- Included a complete JSON configuration example showing how to use `extraKnownMarketplaces` to register custom marketplace repositories
- Demonstrated configuration for 6 marketplace repositories (d-market-typescript, d-market-react, d-market-spec, d-market-git, d-market-doc-gen, and d-market-statusline)
- Specified the correct settings file location (`~/.claude/settings.json`)

## Details
The documentation clarifies that users can extend the marketplace functionality by adding entries to the `extraKnownMarketplaces` configuration object, with each entry specifying a GitHub repository source. This helps users understand how to integrate custom marketplace repositories into their Claude environment.

https://claude.ai/code/session_01HG8QeZS5ArhWqez8kUfEW3